### PR TITLE
Converting file paths to cross-platform file paths

### DIFF
--- a/opstool/post/eigen_data.py
+++ b/opstool/post/eigen_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import shutil
 import time
 from typing import Literal
@@ -209,7 +210,7 @@ def save_eigen_data(
     EIGEN_FILE_NAME = CONFIGS.get_eigen_filename()
     odb_format, _ = CONFIGS.get_odb_format()
 
-    output_filename = RESULTS_DIR + "/" + f"{EIGEN_FILE_NAME}-{odb_tag}.{odb_format}"
+    output_filename = str(Path(RESULTS_DIR) / f"{EIGEN_FILE_NAME}-{odb_tag}.{odb_format}")
     # -----------------------------------------------------------------
     model_info, _ = GetFEMData().get_model_info()
     if model_info == {}:
@@ -274,7 +275,7 @@ def load_eigen_data(
     odb_format, odb_engine = CONFIGS.get_odb_format()
     kargs = {"consolidated": False} if odb_format.lower() == "zarr" else {}
 
-    filename = f"{RESULTS_DIR}/" + f"{EIGEN_FILE_NAME}-{odb_tag}.{odb_format}"
+    filename = str(Path(RESULTS_DIR) / f"{EIGEN_FILE_NAME}-{odb_tag}.{odb_format}")
     if not os.path.exists(filename):
         resave = True
     if resave:

--- a/opstool/post/linear_buckling_data.py
+++ b/opstool/post/linear_buckling_data.py
@@ -1,5 +1,5 @@
 from typing import Optional, Union
-
+from pathlib import Path
 import numpy as np
 import scipy.linalg as slin
 import scipy.sparse as sp
@@ -135,7 +135,7 @@ def save_linear_buckling_data(
     if not isinstance(kmat, xr.DataArray) or not isinstance(kgeo, xr.DataArray):
         raise TypeError("kmat and kgeo must be xarray.DataArray objects.")  # noqa: TRY003
 
-    output_filename = RESULTS_DIR + "/" + f"{BUCKLING_FILE_NAME}-{odb_tag}.{odb_format}"
+    output_filename = str(Path(RESULTS_DIR) / f"{BUCKLING_FILE_NAME}-{odb_tag}.{odb_format}")
     # -----------------------------------------------------------------
     model_info, _ = GetFEMData().get_model_info()
     if model_info == {}:
@@ -166,7 +166,7 @@ def load_linear_buckling_data(odb_tag: Union[str, int]):
     odb_format, odb_engine = CONFIGS.get_odb_format()
     kargs = {"consolidated": False} if odb_format.lower() == "zarr" else {}
 
-    filename = RESULTS_DIR + "/" + f"{BUCKLING_FILE_NAME}-{odb_tag}.{odb_format}"
+    filename = str(Path(RESULTS_DIR) / f"{BUCKLING_FILE_NAME}-{odb_tag}.{odb_format}")
     color = get_random_color()
     CONSOLE.print(f"{PKG_PREFIX} Loading Linear Buckling data from [bold {color}]{filename}[/] ...")
     with xr.open_datatree(filename, engine=odb_engine, **kargs).load() as dt:

--- a/opstool/post/model_data.py
+++ b/opstool/post/model_data.py
@@ -3,6 +3,7 @@ This file contains functions to get data from the current domain of OpenSeesPy
 """
 
 import os
+from pathlib import Path
 import shutil
 import time
 from typing import Union
@@ -426,7 +427,7 @@ def save_model_data(
     MODEL_FILE_NAME = CONFIGS.get_model_filename()
     odb_format, _ = CONFIGS.get_odb_format()
 
-    output_filename = RESULTS_DIR + "/" + f"{MODEL_FILE_NAME}-{odb_tag}.{odb_format}"
+    output_filename = str(Path(RESULTS_DIR) / f"{MODEL_FILE_NAME}-{odb_tag}.{odb_format}")
     model_data = GetFEMData()
     model_info, cells = model_data.get_model_info()
     model_data = {}
@@ -500,7 +501,7 @@ def load_model_data(
     else:
         odb_format, odb_engine = CONFIGS.get_odb_format()
         kargs = {"consolidated": False} if odb_format.lower() == "zarr" else {}
-        filename = f"{RESULTS_DIR}/" + f"{MODEL_FILE_NAME}-{odb_tag}.{odb_format}"
+        filename = str(Path(RESULTS_DIR) / f"{MODEL_FILE_NAME}-{odb_tag}.{odb_format}")
         if not os.path.exists(filename):
             resave = True
         if resave:

--- a/opstool/post/responses_data.py
+++ b/opstool/post/responses_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import shutil
 import time
 import warnings
@@ -298,7 +299,7 @@ class CreateODB:
         self._model_update = model_update
         self._odb_format = CONFIGS.get_odb_format()[0]
         self._flush_every = save_every
-        self._store_path = f"{RESULTS_DIR}\\" + f"{RESP_FILE_NAME}-{self._odb_tag}.odb"
+        self._store_path = str(Path(RESULTS_DIR) / f"{RESP_FILE_NAME}-{self._odb_tag}.odb")
         self._pending_steps = 0
         self._file_idx = 1
         self._zlib = zlib
@@ -359,7 +360,6 @@ class CreateODB:
         return self._RESPS
 
     def _init_path(self):
-        from pathlib import Path
 
         path = Path(self._store_path)
 
@@ -754,7 +754,6 @@ def _load_parts_as_datatree(path) -> list[xr.DataTree]:
       - Returns a list with 1 or more elements.
     """
     import re
-    from pathlib import Path
 
     folder = Path(path)
     pat = re.compile(r"^part_(\d+)(?:\.nc|\.zarr)?$")
@@ -813,7 +812,7 @@ def loadODB(
     PKG_PREFIX = CONFIGS.get_pkg_prefix()
     RESP_FILE_NAME = CONFIGS.get_resp_filename()
 
-    store_path = f"{RESULTS_DIR}\\" + f"{RESP_FILE_NAME}-{odb_tag}.odb"
+    store_path = str(Path(RESULTS_DIR) / f"{RESP_FILE_NAME}-{odb_tag}.odb")
     dts = _load_parts_as_datatree(store_path)
     if verbose:
         color = get_random_color()
@@ -926,13 +925,13 @@ def get_model_data(
             raise ValueError(f"Data type {data_type} not found.")  # noqa: TRY003
 
     if from_responses:
-        filename = f"{RESULTS_DIR}\\" + f"{RESP_FILE_NAME}-{odb_tag}.odb"
+        filename = str(Path(RESULTS_DIR) / f"{RESP_FILE_NAME}-{odb_tag}.odb")
         dts = _load_parts_as_datatree(filename)
         data = ModelInfoStepData.read_data(dts, data_type, lazy=lazy_load)
     else:
         suffix, engine = CONFIGS.get_odb_format()
         kargs = {"consolidated": False} if suffix == "zarr" else {}
-        filename = f"{RESULTS_DIR}\\" + f"{MODEL_FILE_NAME}-{odb_tag}.{suffix}"
+        filename = str(Path(RESULTS_DIR) / f"{MODEL_FILE_NAME}-{odb_tag}.{suffix}")
         with xr.open_datatree(filename, engine=engine, **kargs).load() as dt:
             if data_type not in dt["ModelInfo"]:
                 raise ValueError(f"Data type {data_type} not found in model data.")  # noqa: TRY003
@@ -1013,7 +1012,7 @@ def get_nodal_responses(
     PKG_PREFIX = CONFIGS.get_pkg_prefix()
     RESP_FILE_NAME = CONFIGS.get_resp_filename()
 
-    store_path = f"{RESULTS_DIR}\\" + f"{RESP_FILE_NAME}-{odb_tag}.odb"
+    store_path = str(Path(RESULTS_DIR) / f"{RESP_FILE_NAME}-{odb_tag}.odb")
     dts = _load_parts_as_datatree(store_path)
 
     nodal_resp = NodalRespStepData.read_response(
@@ -1127,7 +1126,7 @@ def get_element_responses(
     PKG_PREFIX = CONFIGS.get_pkg_prefix()
     RESP_FILE_NAME = CONFIGS.get_resp_filename()
 
-    store_path = f"{RESULTS_DIR}\\" + f"{RESP_FILE_NAME}-{odb_tag}.odb"
+    store_path = str(Path(RESULTS_DIR) / f"{RESP_FILE_NAME}-{odb_tag}.odb")
     dts = _load_parts_as_datatree(store_path)
 
     ele_type_l = ele_type.lower()
@@ -1196,7 +1195,7 @@ def get_sensitivity_responses(
     PKG_PREFIX = CONFIGS.get_pkg_prefix()
     RESP_FILE_NAME = CONFIGS.get_resp_filename()
 
-    store_path = f"{RESULTS_DIR}\\" + f"{RESP_FILE_NAME}-{odb_tag}.odb"
+    store_path = str(Path(RESULTS_DIR) / f"{RESP_FILE_NAME}-{odb_tag}.odb")
     dts = _load_parts_as_datatree(store_path)
 
     resp = SensitivityRespStepData.read_response(dts, resp_type=resp_type, lazy=lazy_load)


### PR DESCRIPTION
This relates to [Issue #79](https://github.com/yexiang92/opstool/issues/79#issue-4411342344)

In all four files I found that the file paths were not consistent and were not cross-platform. I therefore modified them to use `str(Path(RESULTS_DIR) / f"filename_etc")` .

`responses_data.py` was the file that was causing me problems because it had hard-wired `\\`. I made the changes here as well and I also added `from pathlib import Path` to the top and removed the imports from the two functions that had the same import.

I have tested the changes for my files and it seems to work, but I recommend that you test it on your files.